### PR TITLE
Add Arabic RTL HTML example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html dir="rtl" lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>مركز تحفيظ القرآن</title>
+  <link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Cairo', sans-serif;
+      font-size: 14px;
+      line-height: 1.75;
+      direction: rtl;
+      text-align: right;
+      margin: 0;
+      padding: 0;
+    }
+    .container {
+      width: 90%;
+      margin: 20px auto;
+    }
+    .header {
+      text-align: center;
+      margin-bottom: 20px;
+    }
+    .login-form {
+      max-width: 400px;
+      margin: auto;
+    }
+    .login-form label {
+      display: block;
+      margin-bottom: 5px;
+    }
+    .login-form input {
+      width: 100%;
+      padding: 8px;
+      margin-bottom: 10px;
+      box-sizing: border-box;
+    }
+    .dashboard {
+      margin-top: 40px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 8px;
+      text-align: right;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1 class="header">نظام إدارة مركز تحفيظ القرآن</h1>
+
+    <div class="login-form">
+      <h2>تسجيل الدخول</h2>
+      <form>
+        <label for="phone">رقم الهاتف</label>
+        <input type="tel" id="phone" placeholder="أدخل رقم هاتفك" required>
+
+        <label for="password">كلمة المرور</label>
+        <input type="password" id="password" placeholder="أدخل كلمة المرور" required>
+
+        <button type="submit">دخول</button>
+      </form>
+    </div>
+
+    <div class="dashboard">
+      <h2>لوحة المعلم</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>اسم الطالب</th>
+            <th>الحضور</th>
+            <th>تقرير الأسبوع</th>
+            <th>الخطة الدراسية</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>أحمد علي</td>
+            <td>موجود</td>
+            <td>ممتاز</td>
+            <td>خطة الحفظ الأسبوعية</td>
+          </tr>
+          <tr>
+            <td>خالد محمد</td>
+            <td>غائب</td>
+            <td>يحتاج متابعة</td>
+            <td>خطة الحفظ الأسبوعية</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` demonstrating an Arabic right-to-left layout for a Quran memorization center

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686411a97c2483228071a568f8931dce